### PR TITLE
changes in license header

### DIFF
--- a/kie-eap-modules/kie-eap-static-modules/org-apache-camel/pom.xml
+++ b/kie-eap-modules/kie-eap-static-modules/org-apache-camel/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2014 JBoss Inc
+  ~ Copyright 2014 Red Hat, Inc. and/or its affiliates.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/kie-eap-modules/kie-eap-static-modules/org-eclipse-aether/pom.xml
+++ b/kie-eap-modules/kie-eap-static-modules/org-eclipse-aether/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2014 JBoss Inc
+  ~ Copyright 2014 Red Hat, Inc. and/or its affiliates.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/kie-eap-modules/kie-eap-static-modules/org-eclipse-sisu/pom.xml
+++ b/kie-eap-modules/kie-eap-static-modules/org-eclipse-sisu/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2014 JBoss Inc
+  ~ Copyright 2014 Red Hat, Inc. and/or its affiliates.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/kie-eap-modules/kie-jboss-eap-base-modules/jboss-eap-6.3/javax-activation-api-main/pom.xml
+++ b/kie-eap-modules/kie-jboss-eap-base-modules/jboss-eap-6.3/javax-activation-api-main/pom.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2014 JBoss Inc
+  ~ Copyright 2014 Red Hat, Inc. and/or its affiliates.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/kie-eap-modules/kie-jboss-eap-base-modules/jboss-eap-6.3/org-picketlink-federation-bindings-main/src/main/resources/picketlink-jbas7-2.5.3.SP10-redhat-1.jar-pom.xml
+++ b/kie-eap-modules/kie-jboss-eap-base-modules/jboss-eap-6.3/org-picketlink-federation-bindings-main/src/main/resources/picketlink-jbas7-2.5.3.SP10-redhat-1.jar-pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?><!--
-  ~ Copyright 2015 JBoss Inc
+  ~ Copyright 2015 Red Hat, Inc. and/or its affiliates.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/kie-fuse-config-editor/src/main/java/org/jboss/integration/fuse/bxms/Config/BxMSIntegrationConfigEditor.java
+++ b/kie-fuse-config-editor/src/main/java/org/jboss/integration/fuse/bxms/Config/BxMSIntegrationConfigEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 JBoss Inc
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-fuse-config-editor/src/main/java/org/jboss/integration/fuse/bxms/Config/ConfigMain.java
+++ b/kie-fuse-config-editor/src/main/java/org/jboss/integration/fuse/bxms/Config/ConfigMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 JBoss Inc
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/EAPBaseModulesDescriptorGenerationMojo.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/EAPBaseModulesDescriptorGenerationMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/EAPBaseMojo.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/EAPBaseMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/EAPDynamicModulesBuilderMojo.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/EAPDynamicModulesBuilderMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/EAPModulesGraphMojo.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/EAPModulesGraphMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/EAPStaticModulesBuilderMojo.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/EAPStaticModulesBuilderMojo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/builder/EAPModulesDependencyBuilder.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/builder/EAPModulesDependencyBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/builder/EAPModulesFlatGraphBuilder.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/builder/EAPModulesFlatGraphBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/builder/EAPModulesGraphBuilder.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/builder/EAPModulesGraphBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/builder/EAPStaticModulesDependencyBuilderImpl.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/builder/EAPStaticModulesDependencyBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/configuration/EAPConfigurationArtifact.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/configuration/EAPConfigurationArtifact.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/configuration/EAPConfigurationModuleDependency.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/configuration/EAPConfigurationModuleDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/distribution/EAPLayerDistributionManager.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/distribution/EAPLayerDistributionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/distribution/EAPStaticLayerDistribution.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/distribution/EAPStaticLayerDistribution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/distribution/EAPXMLLayerDistribution.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/distribution/EAPXMLLayerDistribution.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/eap/EAPFileSystemBaseModulesScanner.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/eap/EAPFileSystemBaseModulesScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/exception/EAPModuleDefinitionException.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/exception/EAPModuleDefinitionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/exception/EAPModuleResourceDuplicationException.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/exception/EAPModuleResourceDuplicationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/exception/EAPModulesDefinitionException.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/exception/EAPModulesDefinitionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/exception/EAPModulesDependencyBuilderException.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/exception/EAPModulesDependencyBuilderException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/common/PathFilter.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/common/PathFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/dependency/EAPBaseModuleDependency.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/dependency/EAPBaseModuleDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/dependency/EAPCustomModuleDependency.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/dependency/EAPCustomModuleDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/dependency/EAPModuleDependency.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/dependency/EAPModuleDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/dependency/EAPModuleMissingDependency.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/dependency/EAPModuleMissingDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/dependency/EAPStaticDistributionModuleDependency.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/dependency/EAPStaticDistributionModuleDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/dependency/EAPStaticModuleDependency.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/dependency/EAPStaticModuleDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/EAPModuleGraphNode.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/EAPModuleGraphNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/EAPModuleGraphNodeDependency.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/EAPModuleGraphNodeDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/EAPModuleGraphNodeResource.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/EAPModuleGraphNodeResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/EAPModulesGraph.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/EAPModulesGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/distribution/EAPModuleGraphDistributionNode.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/distribution/EAPModuleGraphDistributionNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/distribution/EAPModuleGraphDistributionNodeDependency.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/distribution/EAPModuleGraphDistributionNodeDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/distribution/EAPModuleGraphDistributionNodeResource.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/distribution/EAPModuleGraphDistributionNodeResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/distribution/EAPModuleNodeGraphDependency.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/distribution/EAPModuleNodeGraphDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/distribution/EAPModulesDistributionGraph.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/distribution/EAPModulesDistributionGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/flat/EAPModuleGraphFlatNode.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/flat/EAPModuleGraphFlatNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/flat/EAPModuleGraphFlatNodeDependency.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/flat/EAPModuleGraphFlatNodeDependency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/flat/EAPModuleGraphFlatNodeResource.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/flat/EAPModuleGraphFlatNodeResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/flat/EAPModulesFlatGraph.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/graph/flat/EAPModulesFlatGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/layer/EAPLayer.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/layer/EAPLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/layer/EAPLayerImpl.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/layer/EAPLayerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/module/EAPAbstractModule.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/module/EAPAbstractModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/module/EAPBaseModule.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/module/EAPBaseModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/module/EAPDynamicModule.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/module/EAPDynamicModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/module/EAPModule.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/module/EAPModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/module/EAPStaticModule.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/module/EAPStaticModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/resource/EAPAbstractResource.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/resource/EAPAbstractResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/resource/EAPArtifactOptionalResource.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/resource/EAPArtifactOptionalResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/resource/EAPArtifactResource.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/resource/EAPArtifactResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/resource/EAPFileResource.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/resource/EAPFileResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/resource/EAPModuleResource.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/resource/EAPModuleResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/resource/EAPUnresolvableArtifactResource.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/resource/EAPUnresolvableArtifactResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/resource/EAPVersionMismatchedArtifactResource.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/model/resource/EAPVersionMismatchedArtifactResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/scanner/EAPBaseModulesScanner.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/scanner/EAPBaseModulesScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/scanner/EAPModulesScanner.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/scanner/EAPModulesScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/scanner/EAPStaticModulesScanner.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/scanner/EAPStaticModulesScanner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/template/EAPTemplateBuilder.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/template/EAPTemplateBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/template/EAPVelocityTemplateBuilder.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/template/EAPVelocityTemplateBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/util/EAPArtifactUtils.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/util/EAPArtifactUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/util/EAPArtifactsHolder.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/util/EAPArtifactsHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/util/EAPConstants.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/util/EAPConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/util/EAPFileUtils.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/util/EAPFileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/util/EAPXMLUtils.java
+++ b/kie-jboss-modules-plugin/src/main/java/org/kie/integration/eap/maven/util/EAPXMLUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/main/resources/org/kie/integration/eap/maven/assembly/templates/static/assembly.vm
+++ b/kie-jboss-modules-plugin/src/main/resources/org/kie/integration/eap/maven/assembly/templates/static/assembly.vm
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2012 JBoss Inc
+  ~ Copyright 2012 Red Hat, Inc. and/or its affiliates.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/test/java/org/kie/integration/eap/maven/EAPBaseDependencyNodeTest.java
+++ b/kie-jboss-modules-plugin/src/test/java/org/kie/integration/eap/maven/EAPBaseDependencyNodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/test/java/org/kie/integration/eap/maven/EAPBaseLayerTest.java
+++ b/kie-jboss-modules-plugin/src/test/java/org/kie/integration/eap/maven/EAPBaseLayerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/test/java/org/kie/integration/eap/maven/EAPBaseTest.java
+++ b/kie-jboss-modules-plugin/src/test/java/org/kie/integration/eap/maven/EAPBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/test/java/org/kie/integration/eap/maven/EAPStaticLayerTest.java
+++ b/kie-jboss-modules-plugin/src/test/java/org/kie/integration/eap/maven/EAPStaticLayerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/test/java/org/kie/integration/eap/maven/builder/EAPModulesFlatGraphBuilderTest.java
+++ b/kie-jboss-modules-plugin/src/test/java/org/kie/integration/eap/maven/builder/EAPModulesFlatGraphBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/test/java/org/kie/integration/eap/maven/builder/EAPStaticModulesDependencyBuilderTest.java
+++ b/kie-jboss-modules-plugin/src/test/java/org/kie/integration/eap/maven/builder/EAPStaticModulesDependencyBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/test/java/org/kie/integration/eap/maven/scanner/EAPBaseModulesScannerTest.java
+++ b/kie-jboss-modules-plugin/src/test/java/org/kie/integration/eap/maven/scanner/EAPBaseModulesScannerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/test/java/org/kie/integration/eap/maven/scanner/EAPStaticModulesScannerTest.java
+++ b/kie-jboss-modules-plugin/src/test/java/org/kie/integration/eap/maven/scanner/EAPStaticModulesScannerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/test/java/org/kie/integration/eap/maven/util/EAPArtifactUtilsTest.java
+++ b/kie-jboss-modules-plugin/src/test/java/org/kie/integration/eap/maven/util/EAPArtifactUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kie-jboss-modules-plugin/src/test/java/org/kie/integration/eap/maven/util/EAPArtifactsHolderTest.java
+++ b/kie-jboss-modules-plugin/src/test/java/org/kie/integration/eap/maven/util/EAPArtifactsHolderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 JBoss Inc
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
there is an error about com.redhat.fuse:fuse-eap-config:jar:6.2.0.redhat-124 that it is not anymore available in http://repository.jboss.org/nexus/content/groups/public/ - this has nothing to do with this PR
