### PR TITLE
Adjust dependencies after upgrade to IP BOM 6.0.0.Final

### DIFF
--- a/kie-eap-modules/kie-eap-static-modules/org-sonatype-sisu/pom.xml
+++ b/kie-eap-modules/kie-eap-static-modules/org-sonatype-sisu/pom.xml
@@ -35,5 +35,10 @@
       </exclusions>
     </dependency>
 
+    <dependency>
+      <groupId>org.sonatype.sisu</groupId>
+      <artifactId>sisu-inject-bean</artifactId>
+    </dependency>
+
   </dependencies>
 </project>


### PR DESCRIPTION
- the sisu-inject-bean does not seem to be used in
  Drools/jBPM code, but the modules plugin requires it
  (could be a bug in the plugin)

Needs to be merged together with https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/123
