### PR TITLE
kie-eap-installer: use fixed file name to avoid SNAPSHOT timestamps i…

### DIFF
--- a/kie-eap-installer/pom.xml
+++ b/kie-eap-installer/pom.xml
@@ -52,9 +52,10 @@
                 <artifactItem>
                   <groupId>org.kie</groupId>
                   <artifactId>kie-eap-distribution</artifactId>
-                  <version>${project.version}</version>
+                  <version>${version.org.kie}</version>
                   <type>zip</type>
                   <overWrite>true</overWrite>
+                  <destFileName>kie-eap-distribution-${version.org.kie}.zip</destFileName>
                 </artifactItem>
               </artifactItems>
             </configuration>


### PR DESCRIPTION
…n the name
